### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
             laravel: 12.*
           - php: 8.1
             laravel: 13.*
-- php: 8.2
-  laravel: 13.*
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             laravel: 12.*
           - php: 8.1
             laravel: 13.*
+- php: 8.2
+  laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.1, 8.2, 8.3, 8.4 ]
-        laravel: [ 10.*, 11.*, 12.* ]
+        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
+        laravel: [ 10.*, 11.*, 12.*, 13.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         exclude:
           - php: 8.1
             laravel: 11.*
           - php: 8.1
             laravel: 12.*
+          - php: 8.1
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/database": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.21",
-        "laravel/laravel": "^10.0|^11.0|^12.0",
+        "laravel/laravel": "^10.0|^11.0|^12.0|^13.0",
         "mockery/mockery": "^1.5",
         "phpunit/phpunit": "^10.5.17|^11.0"
     },


### PR DESCRIPTION
## Summary
- add Laravel 13 support to composer constraints
- add Laravel 13 and PHP 8.5 to the CI matrix
- exclude Laravel 13 on PHP 8.1, matching the existing exclusions for newer Laravel versions on the lowest PHP version
- update GitHub Actions checkout to v4 while touching the test workflow

## Testing
- composer update
- vendor/bin/phpunit

## Notes
- PHPUnit passes locally on PHP 8.4 after resolving against Laravel 13
- the local test run reports PHPUnit deprecations, but the suite passes
